### PR TITLE
Support optional network_rules for private networking

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,4 +22,22 @@ resource "azurerm_storage_account" "sta" {
   cross_tenant_replication_enabled = var.cross_tenant_replication_enabled # Optional, default: false
   shared_access_key_enabled        = var.shared_access_key_enabled        # Optional, default: true
   public_network_access_enabled    = var.public_network_access_enabled    #Optional, default: true
+
+  dynamic "network_rules" {
+    for_each = var.public_network_access_enabled == false && var.network_rules != null ? [var.network_rules] : []
+    content {
+      default_action             = network_rules.value.default_action
+      bypass                     = network_rules.value.bypass
+      ip_rules                   = network_rules.value.ip_rules
+      virtual_network_subnet_ids = network_rules.value.virtual_network_subnet_ids
+
+      dynamic "private_link_access" {
+        for_each = network_rules.value.private_link_access != null ? [network_rules.value.private_link_access] : []
+        content {
+          endpoint_resource_id = private_link_access.value.endpoint_resource_id
+          endpoint_tenant_id   = private_link_access.value.endpoint_tenant_id
+        }
+      }
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,15 +75,8 @@ variable "public_network_access_enabled" {
 }
 
 variable "network_rules" {
-  description = "(Optional) A network_rules block"
-  type = object({
-    default_action = string
-    bypass = string
-    ip_rules = list(string)
-    virtual_network_subnet_ids = list(string)
-    private_link_access = object({
-      endpoint_resource_id = string
-      endpoint_tenant_id = string
-    })
-  })
+  description = "(Optional) A network_rules block used only when \`public_network_access_enabled\` is false"
+  type        = any
+  default     = null
 }
+


### PR DESCRIPTION
## Summary
- allow `network_rules` variable to be optional
- add dynamic `network_rules` block when public network access is disabled
- restore README file

## Testing
- `terraform fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725e5cf5c4832aaef953c2bcd9f28d